### PR TITLE
Corriendo el borrar todo de la lista de productos comprados

### DIFF
--- a/MiFarma/Funciones.h
+++ b/MiFarma/Funciones.h
@@ -223,12 +223,6 @@ void mergeSort(Lista<Usuario<double, int>*>* l_usuarios, int inicio, int fin) {
 	}
 }
 
-void ordenarUsuarioxEdad(Lista<Usuario<double, int>*>* l_usuarios) {
-	if (l_usuarios->longitud() > 1) {
-		mergeSort(l_usuarios, 0, l_usuarios->longitud() - 1);
-	}
-}
-
 // ordenamiento Quick sort
 int partition(Lista<Producto<string>*>* l_productos, int inicio, int fin) {
 	// Seleccionar el último elemento como pivote
@@ -263,11 +257,5 @@ void quickSort(Lista<Producto<string>*>* l_productos, int inicio, int fin) {
 		// Ordenar las sublistas de manera recursiva
 		quickSort(l_productos, inicio, pi - 1);
 		quickSort(l_productos, pi + 1, fin);
-	}
-}
-
-void ordenarXPrecio(Lista<Producto<string>*>* l_productos) {
-	if (l_productos->longitud() > 1) {
-		quickSort(l_productos, 0, l_productos->longitud() - 1);
 	}
 }

--- a/MiFarma/VistaEmpleado.h
+++ b/MiFarma/VistaEmpleado.h
@@ -597,7 +597,12 @@ public:
 				{
 					l_productos_ordenados->agregaFinal(l_productos->obtenerPos(i));
 				}
-				ordShellProductoMenorAMayor(l_productos_ordenados);
+
+				if (l_productos_ordenados->longitud() > 1) {
+					quickSort(l_productos, 0, l_productos_ordenados->longitud() - 1);
+				}
+
+				//ordShellProductoMenorAMayor(l_productos_ordenados);
 
 				while (!salir)
 				{

--- a/MiFarma/VistaUsuario.h
+++ b/MiFarma/VistaUsuario.h
@@ -265,7 +265,7 @@ public:
 				agregarProducto(l_productos, l_productos_comprados, usuario_actual, cont_productos_comprados);
 				break;
 			case 3:
-				verCarrito(l_productos_comprados, pedido_usuario, c_pedidos, usuario_actual);
+				verCarrito(l_productos_comprados, pedido_usuario, c_pedidos, usuario_actual, cont_productos_comprados);
 				break;
 			case 4:
 				ingresarReclamo(p_reclamos, usuario_actual);
@@ -969,16 +969,18 @@ public:
 		}
 	}
 
-	void eliminarTodoCarrito(Lista<Producto<string>*>* l_productos_comprados)
+	void eliminarTodoCarrito(Lista<Producto<string>*>* l_productos_comprados, int& cont_productos_comprados)
 	{
 		l_productos_comprados->eliminaTodo();
+		cont_productos_comprados = 0;
 		system("cls");
 		mainInterfaz->encuadrar();
 		Console::SetCursorPosition(ANCHO / 4, ALTO / 5 + 9);
 		cout << "Todo los productos del carrito han sido eliminados";
 	}
 	
-	void verCarrito(Lista<Producto<string>*>* l_productos_comprados, Pedido<string>* &pedido_usuario, Cola<Pedido<string>*>* &c_pedidos, Usuario<double, int>* usuario_actual)
+	void verCarrito(Lista<Producto<string>*>* l_productos_comprados, Pedido<string>* &pedido_usuario, Cola<Pedido<string>*>* &c_pedidos, Usuario<double, int>* usuario_actual,
+		int& cont_productos_comprados)
 	{
 		int opcCarrito;
 		int contEspacios = 0;
@@ -1018,7 +1020,7 @@ public:
 				eliminarElementoCarrito(l_productos_comprados);
 				break;
 			case 4:
-				eliminarTodoCarrito(l_productos_comprados);
+				eliminarTodoCarrito(l_productos_comprados, cont_productos_comprados);
 				break;
 			}
 


### PR DESCRIPTION
This pull request includes several changes to the `MiFarma` project, focusing on refactoring sorting functions and modifying methods to handle product counts in the shopping cart. The most important changes include removing redundant sorting functions, updating sorting logic in `VistaEmpleado`, and enhancing the `VistaUsuario` class to manage product counts more effectively.

Refactoring sorting functions:

* Removed the `ordenarUsuarioxEdad` function, which called `mergeSort`, from `Funciones.h` as it was redundant.
* Removed the `ordenarXPrecio` function, which called `quickSort`, from `Funciones.h` for the same reason.

Updating sorting logic:

* Updated the `VistaEmpleado` class to use `quickSort` directly instead of the `ordShellProductoMenorAMayor` function for sorting products.

Enhancing product count management:

* Modified the `VistaUsuario` class to include the `cont_productos_comprados` parameter in the `verCarrito` and `eliminarTodoCarrito` methods to keep track of the number of products in the cart. [[1]](diffhunk://#diff-423606ec76cd5720e07bfa9f3c0b3fd8b748baafbe98f94748603f23a8352393L268-R268) [[2]](diffhunk://#diff-423606ec76cd5720e07bfa9f3c0b3fd8b748baafbe98f94748603f23a8352393L972-R983) [[3]](diffhunk://#diff-423606ec76cd5720e07bfa9f3c0b3fd8b748baafbe98f94748603f23a8352393L1021-R1023)